### PR TITLE
using reverse to resolve post detail URL in url_localized and url_unlocalized

### DIFF
--- a/wordpress_mirror/views.py
+++ b/wordpress_mirror/views.py
@@ -59,17 +59,15 @@ class Post(object):
         if not self._url_localized:
             if self.data:
                 url_parsed = list(urlparse(self.data['url']))
-                url_parsed[2] = sitelanguage().locale_url(url_parsed[2], self.lang)
-                self._url_localized = urlunparse(url_parsed)
+                wp_path = url_parsed[2] if url_parsed[2][0] != '/' else url_parsed[2][1:]
+                url = sitelanguage().reverse('wordpress_blog_mirror_path', args=(wp_path,))
+                self._url_localized = url
         return self._url_localized
 
     @property
     def url_unlocalized(self):
         if not self._url_unlocalized:
-            if self.data:
-                url_parsed = list(urlparse(self.data['url']))
-                url_parsed[2] = sitelanguage().path_without_locale(url_parsed[2])
-                self._url_unlocalized = urlunparse(url_parsed)
+            self.url_unlocalized = sitelanguage().path_without_locale(self.url_localized)
         return self._url_unlocalized
 
     def custom_images(self):


### PR DESCRIPTION
With that I think we can be sure that post detail page will be handled by Django app which uses django-wordpress-mirror.

Now if WORDPRESS_MAPPING host is set to other domain (where Wordpress ls hosted), then url_localized and url_unlocalized are dependant of what Wordpress API returns within 'url' parameter. 